### PR TITLE
set utf-8 char code in base layout

### DIFF
--- a/src/main/twirl/views/Layout.scala.html
+++ b/src/main/twirl/views/Layout.scala.html
@@ -8,6 +8,7 @@
   <title>@title</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/2.0.3/base-context-min.min.css">
   <link rel="stylesheet" href="./assets/style.css">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 </head>
 <body>
 <section id="content">@content</section>


### PR DESCRIPTION
fixed garbled characters.

before:
<img width="369" alt="スクリーンショット 2021-03-08 0 45 39" src="https://user-images.githubusercontent.com/23194090/110246232-1d705100-7faa-11eb-9697-bc8d95cce673.png">

after:
<img width="160" alt="スクリーンショット 2021-03-08 0 36 20" src="https://user-images.githubusercontent.com/23194090/110246234-219c6e80-7faa-11eb-9d52-4429bbe13801.png">
